### PR TITLE
checkGameOver() was called twice when topping out with IHS

### DIFF
--- a/src/game/gamestart.c
+++ b/src/game/gamestart.c
@@ -7884,7 +7884,7 @@ void doHold(int32_t player, int32_t ihs) {
 
 		// ブロックがめり込んでいたらゲームオーバー #1.60c7l2
 		// ゲームオーバーなっていない＆接地している場合は音を鳴らす
-		if( (!checkGameOver(player)) && (judgeBlock(player, bx[player], by[player] + 1, blk[player], rt[player]) != 0) ) {
+		if( (!ihs || repversw < 67) && (!checkGameOver(player)) && (judgeBlock(player, bx[player], by[player] + 1, blk[player], rt[player]) != 0) ) {
 			if( (!isWRule(player)) || (world_drop_snd >= 1) ) PlaySE(1);
 		}
 


### PR DESCRIPTION
`checkGameOver()` was called twice if IHS caused you to top out. It could be called from `statBlock()` or `doHold()`, but `statBlock()` also calls `doHold()`. So, don't check for top out in `doHold()` if it's IHS.

I first noticed this because `checkGameOver()` then calls `setGameOver()` where the grade might be incremented in G2, but it looks like there was another problem where IRS wouldn't save you from topping out if used with IHS since the first check happened before IRS.